### PR TITLE
fix: use identity check for first snapshot and remove redundant snapshot call

### DIFF
--- a/autoppia_iwa/src/data_generation/tests/classes.py
+++ b/autoppia_iwa/src/data_generation/tests/classes.py
@@ -274,7 +274,7 @@ class JudgeBaseOnHTML(BaseTaskTest):
             logger.warning("No browser snapshots provided.")
             return []
 
-        all_htmls = [html for snap in browser_snapshots for html in ([snap.prev_html, snap.current_html] if snap == browser_snapshots[0] else [snap.current_html]) if html]
+        all_htmls = [html for snap in browser_snapshots for html in ([snap.prev_html, snap.current_html] if snap is browser_snapshots[0] else [snap.current_html]) if html]
 
         # Local import to avoid heavy deps during non-LLM tests
         from autoppia_iwa.src.shared.web_utils import clean_html

--- a/autoppia_iwa/src/execution/browser_executor.py
+++ b/autoppia_iwa/src/execution/browser_executor.py
@@ -114,8 +114,6 @@ class PlaywrightBrowserExecutor:
             # backend_events = await self._get_backend_events(web_agent_id, is_web_real)
             if should_record:
                 snapshot_after = await self._capture_snapshot()
-            else:
-                snapshot_after = await self._get_minimal_snapshot_from_page()
 
             backend_events = await self._get_backend_events_for_action(web_agent_id, start_time, is_web_real)
 


### PR DESCRIPTION
Fixes #106

## Changes

### 1. Identity check vs value equality in `collect_all_htmls` (`classes.py`)

Changed `snap == browser_snapshots[0]` to `snap is browser_snapshots[0]`.

`BrowserSnapshot` is a Pydantic model where `==` performs deep field comparison. If two snapshots happen to have identical field values, the condition would incorrectly treat both as the "first" snapshot, causing `prev_html` to be included for non-first snapshots and duplicating HTML entries. Using `is` ensures only the actual first object in the list triggers the special-case behaviour.

### 2. Remove redundant `_get_minimal_snapshot_from_page()` call (`browser_executor.py`)

When `should_record=False`, `_get_minimal_snapshot_from_page()` was being called twice:
- Once at line ~118 (before `_get_backend_events_for_action`)
- Once at line ~123 (after `_get_backend_events_for_action`)

The first result was immediately discarded and overwritten by the second call, making it pure dead code. Removing the first call eliminates a redundant async page evaluation on every non-recording action execution.

## Testing

- 87 unit/config/shared tests pass (`tests/config/`, `tests/shared/`)
- 722 additional tests pass across demo_webs and other non-integration suites
- Pre-existing test failure in `test_demo_webs_service.py::TestLogBackendTest` confirmed unrelated to these changes (fails on unmodified main branch too — missing `dependency_injector` module in test environment)