### PR TITLE
fix: guard against None backend_events and non-numeric film id suffix

### DIFF
--- a/autoppia_iwa/src/evaluation/shared/test_runner.py
+++ b/autoppia_iwa/src/evaluation/shared/test_runner.py
@@ -111,7 +111,7 @@ class TestRunner:
                     _log_backend_test(f"         - Event attributes: {vars(event)}", web_agent_id=web_agent_id)
 
             success = await test.execute_global_test(
-                backend_events=backend_events,
+                backend_events=backend_events or [],
             )
 
             _log_backend_test(f"      - Result: {'✅ PASSED' if success else '❌ FAILED'}", web_agent_id=web_agent_id)

--- a/autoppia_iwa/src/evaluation/shared/utils.py
+++ b/autoppia_iwa/src/evaluation/shared/utils.py
@@ -382,7 +382,8 @@ async def _resolve_autocinema_film_placeholders_in_tests(task: Task, tests_for_r
 
     assigned_film_name = str(assigned_movie.get("name", assigned_movie.get("title", "")))
     assigned_film_id_in_str = str(assigned_movie.get("id", ""))
-    assigned_film_id = str(int(assigned_film_id_in_str.rsplit("-", 1)[-1]))
+    suffix = assigned_film_id_in_str.rsplit("-", 1)[-1]
+    assigned_film_id = str(int(suffix)) if suffix.isdigit() else assigned_film_id_in_str
 
     assigned_film_director = str(assigned_movie.get("director", ""))
     if not assigned_film_name and not assigned_film_id:


### PR DESCRIPTION
Fixes #108

## Changes

### 1. Guard against `None` `backend_events` in `test_runner.py`

Changed `backend_events=backend_events` to `backend_events=backend_events or []` in the call to `test.execute_global_test()`.

When `_get_backend_events_for_action()` returns `None` (e.g. on network error or timeout), the `None` was forwarded directly to the test. Any implementation of `execute_global_test` that iterates over the argument raises `TypeError: 'NoneType' object is not iterable`, crashing the whole evaluation run. The `or []` guard normalises `None` to an empty list, allowing the test to proceed and report no matching events rather than crashing.

### 2. Guard non-numeric film id suffix in `utils.py`

Added a `.isdigit()` check before the `int()` call when parsing the film id suffix extracted via `rsplit("-", 1)[-1]`.

Movie records whose `id` field is a plain string (e.g. `"action-movie"`) produce a non-numeric last segment after the split. The unconditional `int()` call raised `ValueError`, aborting placeholder resolution for that agent and crashing test setup. With the guard, non-numeric suffixes are kept as-is.

## Testing

- 87 unit/config/shared tests pass (`tests/config/`, `tests/shared/`)
- 833 additional tests pass across demo_webs and other non-integration suites
- Pre-existing test failure in `test_demo_webs_service.py::TestLogBackendTest` confirmed unrelated (fails on unmodified main too)